### PR TITLE
Removal of es-module-shims dependency

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
 	"semi": false,
 	"proseWrap": "never",
 	"singleAttributePerLine": false,
-	"printWidth": 999
+	"printWidth": 999,
+	"arrowParens": "avoid"
 }

--- a/app/index.html
+++ b/app/index.html
@@ -18,7 +18,7 @@
 		}
 	</script>
 
-	<main></main>
+	<main>Loading...</main>
 
-	<script type='module' src='./js/index.js'></script>
+	<script async type='module' src='./js/index.js'></script>
 </body>

--- a/app/index.html
+++ b/app/index.html
@@ -1,15 +1,13 @@
 <!DOCTYPE html>
 
 <head>
-	<meta charset='utf-8'>
-	<link rel='stylesheet' href='./css/index.css'>
+	<meta charset="utf-8" />
+	<link rel="stylesheet" href="./css/index.css" />
 </head>
-<body style='margin: 0;'>
-	<script async type='module' src='./vendor/es-module-shims/es-module-shims.js'></script>
-	<script type='importmap'>
+<body>
+	<script type="importmap">
 		{
 			"imports": {
-				"es-module-shims": "./vendor/es-module-shims/es-module-shims.js",
 				"preact": "./vendor/preact/preact.module.js",
 				"preact/jsx-runtime": "./vendor/preact/jsx-runtime/jsxRuntime.module.js",
 				"preact/hooks": "./vendor/preact/hooks/hooks.module.js",
@@ -20,7 +18,7 @@
 		}
 	</script>
 
-	<main>Loading...</main>
+	<main></main>
 
-	<script type='module' src='./js/index.js'></script>
+	<script type="module" src="./js/index.js"></script>
 </body>

--- a/app/index.html
+++ b/app/index.html
@@ -7,13 +7,13 @@
 <body>
 	<script type='importmap'>
 		{
-			'imports': {
-				'preact': './vendor/preact/preact.module.js',
-				'preact/jsx-runtime': './vendor/preact/jsx-runtime/jsxRuntime.module.js',
-				'preact/hooks': './vendor/preact/hooks/hooks.module.js',
-				'ethers': './vendor/ethers/ethers.esm.js',
-				'@preact/signals-core': './vendor/@preact/signals-core/signals-core.module.js',
-				'@preact/signals': './vendor/@preact/signals/signals.module.js'
+			"imports": {
+				"preact": "./vendor/preact/preact.module.js",
+				"preact/jsx-runtime": "./vendor/preact/jsx-runtime/jsxRuntime.module.js",
+				"preact/hooks": "./vendor/preact/hooks/hooks.module.js",
+				"ethers": "./vendor/ethers/ethers.esm.js",
+				"@preact/signals-core": "./vendor/@preact/signals-core/signals-core.module.js",
+				"@preact/signals": "./vendor/@preact/signals/signals.module.js"
 			}
 		}
 	</script>

--- a/app/index.html
+++ b/app/index.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
 
 <head>
-	<meta charset="utf-8" />
-	<link rel="stylesheet" href="./css/index.css" />
+	<meta charset='utf-8' />
+	<link rel='stylesheet' href='./css/index.css' />
 </head>
 <body>
-	<script type="importmap">
+	<script type='importmap'>
 		{
-			"imports": {
-				"preact": "./vendor/preact/preact.module.js",
-				"preact/jsx-runtime": "./vendor/preact/jsx-runtime/jsxRuntime.module.js",
-				"preact/hooks": "./vendor/preact/hooks/hooks.module.js",
-				"ethers": "./vendor/ethers/ethers.esm.js",
-				"@preact/signals-core": "./vendor/@preact/signals-core/signals-core.module.js",
-				"@preact/signals": "./vendor/@preact/signals/signals.module.js"
+			'imports': {
+				'preact': './vendor/preact/preact.module.js',
+				'preact/jsx-runtime': './vendor/preact/jsx-runtime/jsxRuntime.module.js',
+				'preact/hooks': './vendor/preact/hooks/hooks.module.js',
+				'ethers': './vendor/ethers/ethers.esm.js',
+				'@preact/signals-core': './vendor/@preact/signals-core/signals-core.module.js',
+				'@preact/signals': './vendor/@preact/signals/signals.module.js'
 			}
 		}
 	</script>
 
 	<main></main>
 
-	<script type="module" src="./js/index.js"></script>
+	<script type='module' src='./js/index.js'></script>
 </body>

--- a/build/vendor.ts
+++ b/build/vendor.ts
@@ -9,9 +9,9 @@ const dependencyPaths = [
 	{ packageName: 'preact', subfolderToVendor: 'dist', entrypointFile: 'preact.module.js' },
 	{ packageName: 'preact/jsx-runtime', subfolderToVendor: 'dist', entrypointFile: 'jsxRuntime.module.js' },
 	{ packageName: 'preact/hooks', subfolderToVendor: 'dist', entrypointFile: 'hooks.module.js' },
-	{ packageName: 'ethers', subfolderToVendor: 'dist', entrypointFile: 'ethers.esm.js' },
-	{ packageName: '@preact/signals-core', subfolderToVendor: 'dist', entrypointFile: 'signals-core.module.js' },
-	{ packageName: '@preact/signals', subfolderToVendor: 'dist', entrypointFile: 'signals.module.js' },
+	{ packageName: 'ethers', subfolderToVendor: 'dist', entrypointFile: 'ethers.esm.js', },
+	{ packageName: '@preact/signals-core', subfolderToVendor: 'dist', entrypointFile: 'signals-core.module.js', },
+	{ packageName: '@preact/signals', subfolderToVendor: 'dist', entrypointFile: 'signals.module.js' }
 ]
 
 async function vendorDependencies() {
@@ -23,14 +23,12 @@ async function vendorDependencies() {
 
 	const indexHtmlPath = path.join(directoryOfThisFile, '..', 'app', 'index.html')
 	const oldIndexHtml = await fs.readFile(indexHtmlPath, 'utf8')
-	const importmap = dependencyPaths.reduce(
-		(importmap, { packageName, entrypointFile }) => {
-			importmap.imports[packageName] = `./${path.join('.', 'vendor', packageName, entrypointFile).replace(/\\/g, '/')}`
-			return importmap
-		},
-		{ imports: {} as Record<string, string> }
-	)
-	const importmapJson = JSON.stringify(importmap, undefined, '\t').replace(/^/gm, '\t\t')
+	const importmap = dependencyPaths.reduce((importmap, { packageName, entrypointFile }) => {
+		importmap.imports[packageName] = `./${path.join('.', 'vendor', packageName, entrypointFile).replace(/\\/g, '/')}`
+		return importmap
+	}, { imports: {} as Record<string, string> })
+	const importmapJson = JSON.stringify(importmap, undefined, '\t')
+		.replace(/^/mg, '\t\t')
 	const newIndexHtml = oldIndexHtml.replace(/<script type='importmap'>[\s\S]*?<\/script>/m, `<script type='importmap'>\n${importmapJson}\n\t</script>`)
 	await fs.writeFile(indexHtmlPath, newIndexHtml)
 }

--- a/build/vendor.ts
+++ b/build/vendor.ts
@@ -1,15 +1,17 @@
 import * as path from 'path'
-import * as url from 'url';
+import * as url from 'url'
 import { promises as fs } from 'fs'
 import { recursiveDirectoryCopy } from '@zoltu/file-copier'
 
 const directoryOfThisFile = path.dirname(url.fileURLToPath(import.meta.url))
 
 const dependencyPaths = [
-	{ packageName: 'es-module-shims', subfolderToVendor: 'dist', entrypointFile: 'es-module-shims.js' },
 	{ packageName: 'preact', subfolderToVendor: 'dist', entrypointFile: 'preact.module.js' },
 	{ packageName: 'preact/jsx-runtime', subfolderToVendor: 'dist', entrypointFile: 'jsxRuntime.module.js' },
-	{ packageName: 'preact/hooks', subfolderToVendor: 'dist', entrypointFile: 'hooks.module.js' }, { packageName: 'ethers', subfolderToVendor: 'dist', entrypointFile: 'ethers.esm.js', }, { packageName: '@preact/signals-core', subfolderToVendor: 'dist', entrypointFile: 'signals-core.module.js', }, { packageName: '@preact/signals', subfolderToVendor: 'dist', entrypointFile: 'signals.module.js' }
+	{ packageName: 'preact/hooks', subfolderToVendor: 'dist', entrypointFile: 'hooks.module.js' },
+	{ packageName: 'ethers', subfolderToVendor: 'dist', entrypointFile: 'ethers.esm.js' },
+	{ packageName: '@preact/signals-core', subfolderToVendor: 'dist', entrypointFile: 'signals-core.module.js' },
+	{ packageName: '@preact/signals', subfolderToVendor: 'dist', entrypointFile: 'signals.module.js' },
 ]
 
 async function vendorDependencies() {
@@ -21,12 +23,14 @@ async function vendorDependencies() {
 
 	const indexHtmlPath = path.join(directoryOfThisFile, '..', 'app', 'index.html')
 	const oldIndexHtml = await fs.readFile(indexHtmlPath, 'utf8')
-	const importmap = dependencyPaths.reduce((importmap, { packageName, entrypointFile }) => {
-		importmap.imports[packageName] = `./${path.join('.', 'vendor', packageName, entrypointFile).replace(/\\/g, '/')}`
-		return importmap
-	}, { imports: {} as Record<string, string> })
-	const importmapJson = JSON.stringify(importmap, undefined, '\t')
-		.replace(/^/mg, '\t\t')
+	const importmap = dependencyPaths.reduce(
+		(importmap, { packageName, entrypointFile }) => {
+			importmap.imports[packageName] = `./${path.join('.', 'vendor', packageName, entrypointFile).replace(/\\/g, '/')}`
+			return importmap
+		},
+		{ imports: {} as Record<string, string> }
+	)
+	const importmapJson = JSON.stringify(importmap, undefined, '\t').replace(/^/gm, '\t\t')
 	const newIndexHtml = oldIndexHtml.replace(/<script type='importmap'>[\s\S]*?<\/script>/m, `<script type='importmap'>\n${importmapJson}\n\t</script>`)
 	await fs.writeFile(indexHtmlPath, newIndexHtml)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
 			"license": "Unlicense",
 			"dependencies": {
 				"@preact/signals": "1.1.1",
-				"es-module-shims": "1.5.6",
 				"ethers": "5.7.1",
 				"preact": "10.8.1"
 			},
@@ -749,11 +748,6 @@
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
 			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
 		},
-		"node_modules/es-module-shims": {
-			"version": "1.5.6",
-			"resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.5.6.tgz",
-			"integrity": "sha512-P/WNC3j4hncbMjx8mdgNchYaSulXJO8Q7lF6CJthc0Rv3t6ZuzfQnkXkNzluUdgnS9/7mTTJrS9dDgZ2OYbZvA=="
-		},
 		"node_modules/ethers": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.1.tgz",
@@ -1313,11 +1307,6 @@
 					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
 				}
 			}
-		},
-		"es-module-shims": {
-			"version": "1.5.6",
-			"resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.5.6.tgz",
-			"integrity": "sha512-P/WNC3j4hncbMjx8mdgNchYaSulXJO8Q7lF6CJthc0Rv3t6ZuzfQnkXkNzluUdgnS9/7mTTJrS9dDgZ2OYbZvA=="
 		},
 		"ethers": {
 			"version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
 	},
 	"dependencies": {
 		"@preact/signals": "1.1.1",
-		"es-module-shims": "1.5.6",
 		"ethers": "5.7.1",
 		"preact": "10.8.1"
 	},


### PR DESCRIPTION
Most modern browsers now support importmap except Safari. Open for discussion
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap

- [ ] added prettier config to prevent rewriting current code structure