### PR TITLE
Prevent FOUC by adding splash screen

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,9 +2,68 @@
 <html lang='en'>
 
 <head>
+	<title>Lunaria</title>
 	<meta charset='utf-8' />
 	<meta name='viewport' content='width=device-width, initial-scale=1.0' />
 	<link rel='stylesheet' href='./css/index.css' />
+	<style>
+		.splash-screen {
+			position: fixed;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			background-color: black;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			justify-content: center;
+			color: white;
+			visibility: visible;
+			opacity: 1;
+			transform: scale(1);
+			transition: all 400ms 400ms;
+			background: radial-gradient(145.6% 145.6% at 50% 0%, #33003c 0%, #10001f 55.73%, #000000 100%);
+		}
+
+		.splash-screen h1 {
+			margin-bottom: 0.5rem;
+			font-size: 1.5rem;
+			font-weight: bold;
+		}
+
+		.splash-screen--off {
+			visibility: hidden;
+			opacity: 0;
+			pointer-events: none;
+			transform: scale(1.5);
+		}
+
+		.splash-screen circle {
+			animation: fade-dots 0.8s linear infinite;
+		}
+
+		.splash-screen circle:nth-child(1) {
+			animation-delay: -0.8s;
+		}
+
+		.splash-screen circle:nth-child(2) {
+			animation-delay: -0.65s;
+		}
+
+		.splash-screen circle:nth-child(3) {
+			animation-delay: -0.5s;
+		}
+
+		@keyframes fade-dots {
+
+			93.75%,
+			100% {
+				opacity: 0.2;
+			}
+		}
+
+	</style>
 </head>
 
 <body>
@@ -21,7 +80,16 @@
 		}
 	</script>
 
-	<main>Loading...</main>
+	<main></main>
+
+	<section class='splash-screen'>
+		<h1>Lunaria</h1>
+		<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='currentColor'>
+			<circle cx='4' cy='12' r='3' />
+			<circle cx='12' cy='12' r='3' />
+			<circle cx='20' cy='12' r='3' />
+		</svg>
+	</section>
 
 	<script async type='module' src='./js/index.js'></script>
 </body>

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -3,7 +3,7 @@ import { Route, Router, useParams } from './HashRouter.js'
 import { SendEthPage } from './SendEthPage.js'
 
 export function App() {
-	useSplashEffect()
+	executeSplashExit()
 
 	return (
 		<Router>
@@ -27,9 +27,13 @@ const Transaction = () => {
 	)
 }
 
-function useSplashEffect() {
+function executeSplashExit() {
 	useEffect(() => {
-		const element = document.querySelector('.splash-screen')
-		element?.classList.add('splash-screen--off')
+		const selectorClassName = '.splash-screen'
+		const selectorHiddenClassName = 'splash-screen--off'
+
+		const element = document.querySelector(selectorClassName)
+		if (!element || element.classList.contains(selectorHiddenClassName)) return;
+		element.classList.add(selectorHiddenClassName)
 	}, [])
 }

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -1,15 +1,9 @@
 import { useEffect } from 'preact/hooks'
-import { accountStore } from '../store/account.js'
 import { Route, Router, useParams } from './HashRouter.js'
 import { SendEthPage } from './SendEthPage.js'
 
 export function App() {
-	const account = accountStore.value
-
-	useEffect(() => {
-		if (account.status !== 'disconnected') return
-		account.ensureConnected()
-	}, [])
+	useSplashEffect()
 
 	return (
 		<Router>
@@ -31,4 +25,11 @@ const Transaction = () => {
 			</div>
 		</div>
 	)
+}
+
+function useSplashEffect() {
+	useEffect(() => {
+		const element = document.querySelector('.splash-screen')
+		element?.classList.add('splash-screen--off')
+	}, [])
 }

--- a/app/ts/components/SendEthPage.tsx
+++ b/app/ts/components/SendEthPage.tsx
@@ -91,8 +91,8 @@ const Footer = () => {
 
 const Branding = () => (
 	<div class='flex flex-col justify-center items-start grow'>
-		<div class='text-3xl font-bold'>EasyWallet</div>
-		<div class='text-sm text-white/50'>Securing your crypto assets has never been easier</div>
+		<div class='text-3xl font-bold'>Lunaria</div>
+		<div class='text-sm text-white/50'>Manage your digital assets</div>
 	</div>
 )
 


### PR DESCRIPTION
When the page is first loaded, a flash of un-styled content happens while resources are being downloaded. This PR aims to reduce that "flicker" or "jankiness" feel to the app. This effect will be more pronounced once the app introduces handlers for page load and refresh such as #51 which this PR aims to prevent.

Miscellaneous addition:
- used "Lunaria" as brand

NOT included on this PR:
- splash screen icon design #52 

Temporary design

![](https://user-images.githubusercontent.com/1169838/213067391-b67e6eae-8fd5-4c7c-9c15-a34880742585.png)
