### PR TITLE
Inspect Transaction and Search Page

### DIFF
--- a/app/css/index.css
+++ b/app/css/index.css
@@ -470,6 +470,10 @@ video {
 	}
 }
 
+.static {
+	position: static;
+}
+
 .fixed {
 	position: fixed;
 }
@@ -502,9 +506,9 @@ video {
 	margin-bottom: 0.25rem;
 }
 
-.my-2 {
-	margin-top: 0.5rem;
-	margin-bottom: 0.5rem;
+.my-\[10\%\] {
+	margin-top: 10%;
+	margin-bottom: 10%;
 }
 
 .my-4 {
@@ -512,16 +516,21 @@ video {
 	margin-bottom: 1rem;
 }
 
+.my-2 {
+	margin-top: 0.5rem;
+	margin-bottom: 0.5rem;
+}
+
 .mb-2 {
 	margin-bottom: 0.5rem;
 }
 
-.-ml-6 {
-	margin-left: -1.5rem;
-}
-
 .mt-2 {
 	margin-top: 0.5rem;
+}
+
+.-ml-6 {
+	margin-left: -1.5rem;
 }
 
 .mb-4 {
@@ -596,12 +605,12 @@ video {
 	max-width: 24rem;
 }
 
-.max-w-\[40rem\] {
-	max-width: 40rem;
-}
-
 .max-w-lg {
 	max-width: 32rem;
+}
+
+.max-w-\[40rem\] {
+	max-width: 40rem;
 }
 
 .grow {
@@ -770,6 +779,10 @@ video {
 	border-color: rgb(255 255 255 / 0.5);
 }
 
+.border-red-400\/20 {
+	border-color: rgb(248 113 113 / 0.2);
+}
+
 .border-red-400\/50 {
 	border-color: rgb(248 113 113 / 0.5);
 }
@@ -790,20 +803,24 @@ video {
 	background-color: rgb(255 255 255 / 0.5);
 }
 
-.bg-white\/10 {
-	background-color: rgb(255 255 255 / 0.1);
+.bg-red-400\/5 {
+	background-color: rgb(248 113 113 / 0.05);
+}
+
+.bg-black\/10 {
+	background-color: rgb(0 0 0 / 0.1);
 }
 
 .bg-red-400\/10 {
 	background-color: rgb(248 113 113 / 0.1);
 }
 
-.bg-white\/30 {
-	background-color: rgb(255 255 255 / 0.3);
+.bg-white\/10 {
+	background-color: rgb(255 255 255 / 0.1);
 }
 
-.bg-red-400\/5 {
-	background-color: rgb(248 113 113 / 0.05);
+.bg-white\/30 {
+	background-color: rgb(255 255 255 / 0.3);
 }
 
 .p-4 {
@@ -829,6 +846,11 @@ video {
 	padding-bottom: 0.5rem;
 }
 
+.py-3 {
+	padding-top: 0.75rem;
+	padding-bottom: 0.75rem;
+}
+
 .py-4 {
 	padding-top: 1rem;
 	padding-bottom: 1rem;
@@ -842,11 +864,6 @@ video {
 .px-8 {
 	padding-left: 2rem;
 	padding-right: 2rem;
-}
-
-.py-3 {
-	padding-top: 0.75rem;
-	padding-bottom: 0.75rem;
 }
 
 .py-1 {
@@ -882,6 +899,11 @@ video {
 	line-height: 1rem;
 }
 
+.text-xl {
+	font-size: 1.25rem;
+	line-height: 1.75rem;
+}
+
 .text-3xl {
 	font-size: 1.875rem;
 	line-height: 2.25rem;
@@ -889,11 +911,6 @@ video {
 
 .text-lg {
 	font-size: 1.125rem;
-	line-height: 1.75rem;
-}
-
-.text-xl {
-	font-size: 1.25rem;
 	line-height: 1.75rem;
 }
 
@@ -929,6 +946,10 @@ video {
 .text-red-400 {
 	--tw-text-opacity: 1;
 	color: rgb(248 113 113 / var(--tw-text-opacity));
+}
+
+.text-white\/80 {
+	color: rgb(255 255 255 / 0.8);
 }
 
 .text-white {

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -497,30 +497,43 @@ video {
 	grid-row: span 2 / span 2;
 }
 
-.my-3 {
-	margin-top: 0.75rem;
-	margin-bottom: 0.75rem;
-}
-
 .my-1 {
 	margin-top: 0.25rem;
 	margin-bottom: 0.25rem;
 }
 
-.-ml-6 {
-	margin-left: -1.5rem;
+.my-2 {
+	margin-top: 0.5rem;
+	margin-bottom: 0.5rem;
+}
+
+.my-4 {
+	margin-top: 1rem;
+	margin-bottom: 1rem;
 }
 
 .mb-2 {
 	margin-bottom: 0.5rem;
 }
 
+.-ml-6 {
+	margin-left: -1.5rem;
+}
+
 .mt-2 {
 	margin-top: 0.5rem;
 }
 
-.mb-6 {
-	margin-bottom: 1.5rem;
+.mb-4 {
+	margin-bottom: 1rem;
+}
+
+.mb-8 {
+	margin-bottom: 2rem;
+}
+
+.mt-4 {
+	margin-top: 1rem;
 }
 
 .flex {
@@ -547,6 +560,10 @@ video {
 	height: 4rem;
 }
 
+.h-full {
+	height: 100%;
+}
+
 .min-h-\[4rem\] {
 	min-height: 4rem;
 }
@@ -563,12 +580,28 @@ video {
 	width: 6rem;
 }
 
+.w-96 {
+	width: 24rem;
+}
+
+.w-64 {
+	width: 16rem;
+}
+
 .min-w-\[11rem\] {
 	min-width: 11rem;
 }
 
 .max-w-sm {
 	max-width: 24rem;
+}
+
+.max-w-\[40rem\] {
+	max-width: 40rem;
+}
+
+.max-w-lg {
+	max-width: 32rem;
 }
 
 .grow {
@@ -611,6 +644,10 @@ video {
 	grid-template-columns: minmax(min-content, max-content) minmax(auto, max-content);
 }
 
+.grid-cols-1 {
+	grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
 .grid-rows-\[minmax\(min-content\2c max-content\)\] {
 	grid-template-rows: minmax(min-content, max-content);
 }
@@ -619,12 +656,20 @@ video {
 	grid-template-rows: minmax(min-content, max-content) minmax(min-content, auto) minmax(min-content, max-content);
 }
 
+.grid-rows-\[minmax\(min-content\2c max-content\)_1fr\] {
+	grid-template-rows: minmax(min-content, max-content) 1fr;
+}
+
 .grid-rows-\[repeat\(auto-fit\2c minmax\(min-content\2c 0\)\)\] {
 	grid-template-rows: repeat(auto-fit, minmax(min-content, 0));
 }
 
 .flex-col {
 	flex-direction: column;
+}
+
+.flex-wrap {
+	flex-wrap: wrap;
 }
 
 .items-start {
@@ -668,8 +713,21 @@ video {
 	row-gap: 1rem;
 }
 
+.gap-x-6 {
+	-moz-column-gap: 1.5rem;
+	column-gap: 1.5rem;
+}
+
+.gap-y-1 {
+	row-gap: 0.25rem;
+}
+
 .overflow-hidden {
 	overflow: hidden;
+}
+
+.overflow-scroll {
+	overflow: scroll;
 }
 
 .overflow-y-scroll {
@@ -716,6 +774,14 @@ video {
 	border-color: rgb(248 113 113 / 0.5);
 }
 
+.border-white\/10 {
+	border-color: rgb(255 255 255 / 0.1);
+}
+
+.border-red-400\/30 {
+	border-color: rgb(248 113 113 / 0.3);
+}
+
 .bg-white\/5 {
 	background-color: rgb(255 255 255 / 0.05);
 }
@@ -732,8 +798,20 @@ video {
 	background-color: rgb(248 113 113 / 0.1);
 }
 
+.bg-white\/30 {
+	background-color: rgb(255 255 255 / 0.3);
+}
+
+.bg-red-400\/5 {
+	background-color: rgb(248 113 113 / 0.05);
+}
+
 .p-4 {
 	padding: 1rem;
+}
+
+.p-2 {
+	padding: 0.5rem;
 }
 
 .px-3 {
@@ -761,11 +839,6 @@ video {
 	padding-right: 1.5rem;
 }
 
-.py-1 {
-	padding-top: 0.25rem;
-	padding-bottom: 0.25rem;
-}
-
 .px-8 {
 	padding-left: 2rem;
 	padding-right: 2rem;
@@ -774,6 +847,21 @@ video {
 .py-3 {
 	padding-top: 0.75rem;
 	padding-bottom: 0.75rem;
+}
+
+.py-1 {
+	padding-top: 0.25rem;
+	padding-bottom: 0.25rem;
+}
+
+.px-2 {
+	padding-left: 0.5rem;
+	padding-right: 0.5rem;
+}
+
+.py-\[10\%\] {
+	padding-top: 10%;
+	padding-bottom: 10%;
 }
 
 .text-center {
@@ -794,11 +882,6 @@ video {
 	line-height: 1rem;
 }
 
-.text-xl {
-	font-size: 1.25rem;
-	line-height: 1.75rem;
-}
-
 .text-3xl {
 	font-size: 1.875rem;
 	line-height: 2.25rem;
@@ -807,6 +890,16 @@ video {
 .text-lg {
 	font-size: 1.125rem;
 	line-height: 1.75rem;
+}
+
+.text-xl {
+	font-size: 1.25rem;
+	line-height: 1.75rem;
+}
+
+.text-2xl {
+	font-size: 1.5rem;
+	line-height: 2rem;
 }
 
 .font-bold {
@@ -843,12 +936,16 @@ video {
 	color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
+.text-white\/30 {
+	color: rgb(255 255 255 / 0.3);
+}
+
 .text-white\/20 {
 	color: rgb(255 255 255 / 0.2);
 }
 
-.text-white\/30 {
-	color: rgb(255 255 255 / 0.3);
+.underline-offset-4 {
+	text-underline-offset: 4px;
 }
 
 .outline-none {
@@ -866,6 +963,18 @@ video {
 	transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
 	transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 	transition-duration: 150ms;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+	display: none;
+	/* Chrome, Safari and Opera */
+}
+
+.no-scrollbar {
+	-ms-overflow-style: none;
+	/* IE and Edge */
+	scrollbar-width: none;
+	/* Firefox */
 }
 
 .bg-polka {
@@ -922,6 +1031,10 @@ video {
 	}
 }
 
+.\[grid-template-areas\:_\"header\"_\"body\"_\"footer\"\] {
+	grid-template-areas: 'header' 'body' 'footer';
+}
+
 .\[grid-area\:header\] {
 	grid-area: header;
 }
@@ -930,16 +1043,8 @@ video {
 	grid-area: body;
 }
 
-.\[grid-area\:footer\] {
-	grid-area: footer;
-}
-
-.\[grid-area\:brand\] {
-	grid-area: brand;
-}
-
-.\[grid-area\:profile\] {
-	grid-area: profile;
+.\[grid-template-areas\:_\"essentials\"_\"main\"_\"aside\"\] {
+	grid-template-areas: 'essentials' 'main' 'aside';
 }
 
 .\[grid-area\:essentials\] {
@@ -954,16 +1059,8 @@ video {
 	grid-area: aside;
 }
 
-.\[grid-template-areas\:_\"header\"_\"body\"_\"footer\"\] {
-	grid-template-areas: 'header' 'body' 'footer';
-}
-
-.\[grid-template-areas\:_\"brand\"_\"profile\"\] {
-	grid-template-areas: 'brand' 'profile';
-}
-
-.\[grid-template-areas\:_\"essentials\"_\"main\"_\"aside\"\] {
-	grid-template-areas: 'essentials' 'main' 'aside';
+.\[grid-area\:footer\] {
+	grid-area: footer;
 }
 
 .\[grid-template-areas\:_\"title\"_\"token\"_\"amount\"_\"address\"_\"tip\"_\"controls\"\] {
@@ -994,6 +1091,14 @@ video {
 	grid-area: controls;
 }
 
+.placeholder\:text-white\/30::-moz-placeholder {
+	color: rgb(255 255 255 / 0.3);
+}
+
+.placeholder\:text-white\/30::placeholder {
+	color: rgb(255 255 255 / 0.3);
+}
+
 .invalid\:text-red-200:invalid {
 	--tw-text-opacity: 1;
 	color: rgb(254 202 202 / var(--tw-text-opacity));
@@ -1015,6 +1120,10 @@ video {
 .hover\:text-white:hover {
 	--tw-text-opacity: 1;
 	color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+.hover\:underline:hover {
+	text-decoration-line: underline;
 }
 
 .focus\:border-white:focus {
@@ -1076,12 +1185,12 @@ video {
 		grid-auto-flow: column;
 	}
 
-	.md\:grid-cols-\[3fr_2fr\] {
-		grid-template-columns: 3fr 2fr;
+	.md\:grid-cols-\[minmax\(min-content\2c auto\)\2c minmax\(min-content\2c 1fr\)\] {
+		grid-template-columns: minmax(min-content, auto) minmax(min-content, 1fr);
 	}
 
-	.md\:grid-rows-\[minmax\(min-content\2c max-content\)_1fr\] {
-		grid-template-rows: minmax(min-content, max-content) 1fr;
+	.md\:grid-cols-\[3fr_2fr\] {
+		grid-template-columns: 3fr 2fr;
 	}
 
 	.md\:place-items-end {
@@ -1096,12 +1205,21 @@ video {
 		align-items: center;
 	}
 
+	.md\:justify-end {
+		justify-content: flex-end;
+	}
+
 	.md\:justify-between {
 		justify-content: space-between;
 	}
 
 	.md\:gap-1 {
 		gap: 0.25rem;
+	}
+
+	.md\:gap-x-6 {
+		-moz-column-gap: 1.5rem;
+		column-gap: 1.5rem;
 	}
 
 	.md\:border-0 {
@@ -1126,8 +1244,9 @@ video {
 		line-height: 1.25rem;
 	}
 
-	.md\:\[grid-template-areas\:_\"brand_profile\"\] {
-		grid-template-areas: 'brand profile';
+	.md\:text-3xl {
+		font-size: 1.875rem;
+		line-height: 2.25rem;
 	}
 
 	.md\:\[grid-template-areas\:_\"main_essentials\"_\"main_aside\"\] {
@@ -1151,12 +1270,20 @@ video {
 }
 
 @media (min-width: 1280px) {
+	.xl\:col-span-full {
+		grid-column: 1 / -1;
+	}
+
 	.xl\:grid-cols-\[5fr_2fr\] {
 		grid-template-columns: 5fr 2fr;
 	}
 
 	.xl\:grid-cols-3 {
 		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	.xl\:grid-cols-\[repeat\(2\2c _minmax\(min-content\2c _1fr\)\)\] {
+		grid-template-columns: repeat(2, minmax(min-content, 1fr));
 	}
 
 	.xl\:justify-start {

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -1063,14 +1063,6 @@ video {
 	grid-area: footer;
 }
 
-.\[grid-template-areas\:_\"title\"_\"token\"_\"amount\"_\"address\"_\"tip\"_\"controls\"\] {
-	grid-template-areas: 'title' 'token' 'amount' 'address' 'tip' 'controls';
-}
-
-.\[grid-area\:title\] {
-	grid-area: title;
-}
-
 .\[grid-area\:token\] {
 	grid-area: token;
 }
@@ -1089,6 +1081,14 @@ video {
 
 .\[grid-area\:controls\] {
 	grid-area: controls;
+}
+
+.\[grid-template-areas\:_\"title\"_\"token\"_\"amount\"_\"address\"_\"tip\"_\"controls\"\] {
+	grid-template-areas: 'title' 'token' 'amount' 'address' 'tip' 'controls';
+}
+
+.\[grid-area\:title\] {
+	grid-area: title;
 }
 
 .placeholder\:text-white\/30::-moz-placeholder {

--- a/app/css/index.css
+++ b/app/css/index.css
@@ -516,6 +516,11 @@ video {
 	margin-bottom: 1rem;
 }
 
+.my-3 {
+	margin-top: 0.75rem;
+	margin-bottom: 0.75rem;
+}
+
 .my-2 {
 	margin-top: 0.5rem;
 	margin-bottom: 0.5rem;
@@ -525,8 +530,12 @@ video {
 	margin-bottom: 0.5rem;
 }
 
-.mt-2 {
-	margin-top: 0.5rem;
+.mb-3 {
+	margin-bottom: 0.75rem;
+}
+
+.mt-3 {
+	margin-top: 0.75rem;
 }
 
 .-ml-6 {
@@ -731,6 +740,10 @@ video {
 	row-gap: 0.25rem;
 }
 
+.overflow-auto {
+	overflow: auto;
+}
+
 .overflow-hidden {
 	overflow: hidden;
 }
@@ -866,14 +879,14 @@ video {
 	padding-right: 2rem;
 }
 
-.py-1 {
-	padding-top: 0.25rem;
-	padding-bottom: 0.25rem;
-}
-
 .px-2 {
 	padding-left: 0.5rem;
 	padding-right: 0.5rem;
+}
+
+.py-1 {
+	padding-top: 0.25rem;
+	padding-bottom: 0.25rem;
 }
 
 .py-\[10\%\] {
@@ -1104,12 +1117,12 @@ video {
 	grid-area: controls;
 }
 
-.\[grid-template-areas\:_\"title\"_\"token\"_\"amount\"_\"address\"_\"tip\"_\"controls\"\] {
-	grid-template-areas: 'title' 'token' 'amount' 'address' 'tip' 'controls';
-}
-
 .\[grid-area\:title\] {
 	grid-area: title;
+}
+
+.\[grid-template-areas\:_\"title\"_\"token\"_\"amount\"_\"address\"_\"tip\"_\"controls\"\] {
+	grid-template-areas: 'title' 'token' 'amount' 'address' 'tip' 'controls';
 }
 
 .placeholder\:text-white\/30::-moz-placeholder {
@@ -1305,10 +1318,6 @@ video {
 
 	.xl\:grid-cols-\[repeat\(2\2c _minmax\(min-content\2c _1fr\)\)\] {
 		grid-template-columns: repeat(2, minmax(min-content, 1fr));
-	}
-
-	.xl\:justify-start {
-		justify-content: flex-start;
 	}
 
 	.xl\:border-l-4 {

--- a/app/ts/components/App.tsx
+++ b/app/ts/components/App.tsx
@@ -1,29 +1,26 @@
 import { useEffect } from 'preact/hooks'
-import { Route, Router, useParams } from './HashRouter.js'
+import { accountStore } from '../store/account.js'
+import { Route, Router } from './HashRouter.js'
 import { SendEthPage } from './SendEthPage.js'
+import { TransactionDetailsPage } from './TransactionDetailsPage.js'
+import { TransactionPage } from './TransactionPage.js'
 
 export function App() {
+	const account = accountStore.value
+
+	useEffect(() => {
+		if (account.status !== 'disconnected') return
+		account.ensureConnected()
+	}, [])
+
 	executeSplashExit()
 
 	return (
 		<Router>
-			<Route path='#tx/:transaction_hash' component={Transaction} />
+			<Route path='#tx' component={TransactionPage} />
+			<Route path='#tx/:transaction_hash' component={TransactionDetailsPage} />
 			<Route path='/' component={SendEthPage} />
 		</Router>
-	)
-}
-
-const Transaction = () => {
-	const params = useParams()
-	const hash = params && 'transaction_hash' in params && params.transaction_hash
-
-	return (
-		<div class='px-4'>
-			<h4 class='my-3'>Transaction Details</h4>
-			<div>
-				Transaction Hash: <strong>{hash}</strong>
-			</div>
-		</div>
 	)
 }
 

--- a/app/ts/components/ConnectToWallet.tsx
+++ b/app/ts/components/ConnectToWallet.tsx
@@ -53,12 +53,14 @@ export const ConnectToWallet = () => {
 		case 'rejected':
 			if (account.error instanceof EthereumJsonRpcError) {
 				return (
-					<div class='text-center md:text-right'>
-						<div class='font-bold'>Failed to connect to wallet!</div>
-						<a class='text-sm text-white/50 flex items-center justify-center gap-1 italic' title={`${account.error.message} (${account.error.code})`}>
-							<span>Open your wallet extension window for details</span>️ <Icon.Info />
-						</a>
-					</div>
+					<Wrapper>
+						<div class='text-center md:text-right'>
+							<div class='font-bold'>Failed to connect to wallet!</div>
+							<a class='text-sm text-white/50 flex items-center justify-center gap-1 italic' title={`${account.error.message} (${account.error.code})`}>
+								<span>Open your wallet extension window for details</span>️ <Icon.Info />
+							</a>
+						</div>
+					</Wrapper>
 				)
 			}
 
@@ -76,5 +78,5 @@ export const ConnectToWallet = () => {
 }
 
 const Wrapper = ({ children }: { children: ComponentChildren }) => {
-	return <div class='flex items-center justify-center border border-dashed border-white/30 md:border-0 rounded min-h-[4rem] md:min-h-0 px-3 md:px-0'>{children}</div>
+	return <div class='flex items-center justify-center md:justify-end border border-dashed border-white/30 md:border-0 rounded min-h-[4rem] md:min-h-0 px-3 md:px-0'>{children}</div>
 }

--- a/app/ts/components/ErrorBoundary.tsx
+++ b/app/ts/components/ErrorBoundary.tsx
@@ -1,26 +1,24 @@
-import { Component, JSX } from 'preact';
+import { Component, JSX, ErrorInfo } from 'preact'
 
 interface Props {
 	children: JSX.Element | JSX.Element[]
 }
 
-interface State {
-	hasError: boolean;
-	error: Error | null;
-}
+type State = { hasError: false } | { hasError: true; error: Error }
 
 class ErrorBoundary extends Component<Props, State> {
 	constructor(props: Props) {
-		super(props);
-		this.state = { hasError: false, error: null };
+		super(props)
+		this.state = { hasError: false }
 	}
 
 	static getDerivedStateFromError(error: Error) {
-		return { hasError: true, error };
+		return { hasError: true, error }
 	}
 
-	componentDidCatch(error: Error, errorInfo: object) {
-		console.error(error, errorInfo);
+	componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+		// connect to logging service
+		console.error(error, errorInfo)
 	}
 
 	render() {
@@ -30,14 +28,14 @@ class ErrorBoundary extends Component<Props, State> {
 					<div class='border border-red-400/20 bg-red-400/5 p-4 text-center max-w-lg'>
 						<div class='text-xl font-bold'>Uh oh, this is unexpected...</div>
 						<div class='text-white/50 text-sm my-4'>Not to worry. Drop by our disord channel and provide us with the hint below so we can help resolve your issue faster. Appreciate your support and look forward to seeing you there.</div>
-						<div class='border border-red-400/20 px-4 py-3 bg-black/10 text-white/80 text-sm'>{this.state.error?.message}</div>
+						<div class='border border-red-400/20 px-4 py-3 bg-black/10 text-white/80 text-sm'>{this.state.error.message}</div>
 					</div>
 				</div>
-			);
+			)
 		}
 
-		return this.props.children;
+		return this.props.children
 	}
 }
 
-export default ErrorBoundary;
+export default ErrorBoundary

--- a/app/ts/components/ErrorBoundary.tsx
+++ b/app/ts/components/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import { Component, JSX } from 'preact';
+
+interface Props {
+	children: JSX.Element | JSX.Element[]
+}
+
+interface State {
+	hasError: boolean;
+	error: Error | null;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+	constructor(props: Props) {
+		super(props);
+		this.state = { hasError: false, error: null };
+	}
+
+	static getDerivedStateFromError(error: Error) {
+		return { hasError: true, error };
+	}
+
+	componentDidCatch(error: Error, errorInfo: object) {
+		console.error(error, errorInfo);
+	}
+
+	render() {
+		if (this.state.hasError) {
+			return (
+				<div class='w-full my-[10%] flex justify-center'>
+					<div class='border border-red-400/20 bg-red-400/5 p-4 text-center max-w-lg'>
+						<div class='text-xl font-bold'>Uh oh, this is unexpected...</div>
+						<div class='text-white/50 text-sm my-4'>Not to worry. Drop by our disord channel and provide us with the hint below so we can help resolve your issue faster. Appreciate your support and look forward to seeing you there.</div>
+						<div class='border border-red-400/20 px-4 py-3 bg-black/10 text-white/80 text-sm'>{this.state.error?.message}</div>
+					</div>
+				</div>
+			);
+		}
+
+		return this.props.children;
+	}
+}
+
+export default ErrorBoundary;

--- a/app/ts/components/ErrorBoundary.tsx
+++ b/app/ts/components/ErrorBoundary.tsx
@@ -22,19 +22,17 @@ class ErrorBoundary extends Component<Props, State> {
 	}
 
 	render() {
-		if (this.state.hasError) {
-			return (
-				<div class='w-full my-[10%] flex justify-center'>
-					<div class='border border-red-400/20 bg-red-400/5 p-4 text-center max-w-lg'>
-						<div class='text-xl font-bold'>Uh oh, this is unexpected...</div>
-						<div class='text-white/50 text-sm my-4'>Not to worry. Drop by our disord channel and provide us with the hint below so we can help resolve your issue faster. Appreciate your support and look forward to seeing you there.</div>
-						<div class='border border-red-400/20 px-4 py-3 bg-black/10 text-white/80 text-sm'>{this.state.error.message}</div>
-					</div>
-				</div>
-			)
-		}
+		if (!this.state.hasError) return this.props.children
 
-		return this.props.children
+		return (
+			<div class='w-full my-[10%] flex justify-center'>
+				<div class='border border-red-400/20 bg-red-400/5 p-4 text-center max-w-lg'>
+					<div class='text-xl font-bold'>Uh oh, this is unexpected...</div>
+					<div class='text-white/50 text-sm my-4'>Not to worry. Drop by our disord channel and provide us with the hint below so we can help resolve your issue faster. Appreciate your support and look forward to seeing you there.</div>
+					<div class='border border-red-400/20 px-4 py-3 bg-black/10 text-white/80 text-sm'>{this.state.error.message}</div>
+				</div>
+			</div>
+		)
 	}
 }
 

--- a/app/ts/components/Layout.tsx
+++ b/app/ts/components/Layout.tsx
@@ -1,29 +1,101 @@
 import { ComponentChildren, JSX } from 'preact'
 import { removeNonStringsAndTrim } from '../library/utilities.js'
+import * as Icon from './Icon/index.js'
+import { ConnectToWallet } from './ConnectToWallet.js'
 
 type LayoutComponentProps = JSX.HTMLAttributes<HTMLDivElement> & { children: ComponentChildren }
 
 export const Page = ({ children, class: classString }: LayoutComponentProps) => {
-	const classNames = removeNonStringsAndTrim(`absolute inset-0 text-white overflow-y-scroll`, classString)
+	const classNames = removeNonStringsAndTrim(`absolute inset-0 text-white overflow-y-scroll grid [grid-template-areas:_"header"_"body"_"footer"] grid-rows-[minmax(min-content,max-content)_minmax(min-content,auto)_minmax(min-content,max-content)]`, classString)
 	return (
 		<div class='fixed bg-main inset-0'>
 			<div class='fixed inset-0 bg-polka'></div>
-			<div class={classNames}>{children}</div>
+			<div class={classNames}>
+				{children}
+			</div>
 		</div>
 	)
 }
 
-export const Header = ({ children, class: classString }: LayoutComponentProps) => {
-	const classNames = removeNonStringsAndTrim(`[grid-area:header]`, classString)
-	return <div class={classNames}>{children}</div>
+export const Header = () => {
+	return (
+		<div class='[grid-area:header] grid md:grid-cols-[minmax(min-content,auto),minmax(min-content,1fr)] md:gap-x-6  md:items-center md:justify-between gap-4 py-4 px-6'>
+			<Branding />
+			<ConnectToWallet />
+		</div>
+	)
 }
 
-export const Body = ({ children, class: classString }: LayoutComponentProps) => {
-	const classNames = removeNonStringsAndTrim(`[grid-area:body]`, classString)
-	return <div class={classNames}>{children}</div>
+export const Body = ({ children }: { children: ComponentChildren }) => {
+	return <div class='[grid-area:body] grid gap-6 [grid-template-areas:_"essentials"_"main"_"aside"] md:[grid-template-areas:_"main_essentials"_"main_aside"] md:grid-cols-[3fr_2fr] xl:grid-cols-[5fr_2fr] grid-rows-[minmax(min-content,max-content)_1fr] px-6'>
+		<div class='[grid-area:essentials]'>
+			<ActiveNetwork />
+			<EthBalance />
+		</div>
+		<div class='[grid-area:main]'>
+			{children}
+		</div>
+		<div class='[grid-area:aside]'>
+			<Support />
+		</div>
+	</div>
 }
 
-export const Footer = ({ children, class: classString }: LayoutComponentProps) => {
-	const classNames = removeNonStringsAndTrim(`[grid-area:footer]`, classString)
-	return <div class={classNames}>{children}</div>
+export const Footer = () => {
+	return (
+		<div class='[grid-area:footer] h-16 col-span-2 flex items-center justify-center px-8'>
+			<SocialLinks />
+		</div>
+	)
 }
+
+const Branding = () => (
+	<div class='flex flex-col justify-center items-start grow'>
+		<div class='text-3xl font-bold'>Lunaria</div>
+		<div class='text-sm text-white/50'>Decentralized • Open • Non-custodial</div>
+	</div>
+)
+
+const SocialLinks = () => (
+	<div class='flex items-center gap-6 text-white/30'>
+		<a class='text-white/30 hover:text-white' href='/'>
+			Github
+		</a>
+		<a class='text-white/30 hover:text-white' href='/'>
+			Twitter
+		</a>
+		<a class='text-white/30 hover:text-white' target='' href='https://discord.gg/gU8BNhqj'>
+			Discord
+		</a>
+	</div>
+)
+
+const Support = () => {
+	return (
+		<div class='bg-white/5 py-3 px-6 hover:bg-white/5 text-center md:text-left'>
+			<div class='font-bold text-lg mb-2'>Need support?</div>
+			<div class='text-sm text-white/50 mb-2'>Join our discord channel to get support from our active community members and stay up-to-date with the latest news, events, and announcements.</div>
+		</div>
+	)
+}
+
+const EthBalance = () => (
+	<div class='flex flex-col items-center justify-center md:items-start md:gap-1 mb-2'>
+		<div class='uppercase text-white/50 text-xs md:text-sm'>balance (ETH)</div>
+		<div class='flex items-center gap-2'>
+			<div class='text-lg font-bold capitalize'>100.0159 ETH</div>
+			<button type='button' class='focus:outline-none focus:bg-white/10 focus:ring-1 focus:ring-white rounded' title='Refresh' onClick={() => { }}>
+				<Icon.Refresh />
+			</button>
+		</div>
+	</div>
+)
+
+const ActiveNetwork = () => (
+	<div class='flex flex-col items-center justify-center md:items-start md:gap-1 mb-2'>
+		<div class='uppercase text-white/50 text-xs md:text-sm'>network</div>
+		<div class='text-lg font-bold capitalize' title='0x5'>
+			Goerli
+		</div>
+	</div>
+)

--- a/app/ts/components/Layout.tsx
+++ b/app/ts/components/Layout.tsx
@@ -58,10 +58,10 @@ const Branding = () => (
 
 const SocialLinks = () => (
 	<div class='flex items-center gap-6 text-white/30'>
-		<a class='text-white/30 hover:text-white' href='/'>
+		<a class='text-white/30 hover:text-white' href='https://github.com/DarkFlorist'>
 			Github
 		</a>
-		<a class='text-white/30 hover:text-white' href='/'>
+		<a class='text-white/30 hover:text-white' href='https://twitter.com/DarkFlorist'>
 			Twitter
 		</a>
 		<a class='text-white/30 hover:text-white' target='' href='https://discord.gg/gU8BNhqj'>

--- a/app/ts/components/SendEthPage.tsx
+++ b/app/ts/components/SendEthPage.tsx
@@ -1,6 +1,4 @@
 import * as Layout from './Layout.js'
-import * as Icon from './Icon/index.js'
-import { ConnectToWallet } from './ConnectToWallet.js'
 import { AddressField } from './AddressField.js'
 import { AmountField } from './AmountField.js'
 import { ComponentChildren } from 'preact'
@@ -11,48 +9,15 @@ import { assertUnreachable } from '../library/utilities.js'
 
 export const SendEthPage = () => {
 	return (
-		<Page>
-			<Header>
-				<div class='[grid-area:brand]'>
-					<Branding />
-				</div>
-				<div class='[grid-area:profile]'>
-					<ConnectToWallet />
-				</div>
-			</Header>
-
-			<Body>
-				<div class='[grid-area:essentials]'>
-					<ActiveNetwork />
-					<EthBalance />
-				</div>
-				<div class='[grid-area:main]'>
-					<Main />
-				</div>
-				<div class='[grid-area:aside]'>
-					<Support />
-				</div>
-			</Body>
-
-			<Footer />
-		</Page>
+		<Layout.Page>
+			<Layout.Header />
+			<Layout.Body>
+				<Main />
+			</Layout.Body>
+			<Layout.Footer />
+		</Layout.Page>
 	)
 }
-
-export type SendTransactionInput = {
-	amount: string
-	to: string
-}
-
-const Page = ({ children }: { children: ComponentChildren }) => {
-	return (
-		<Layout.Page class='grid [grid-template-areas:_"header"_"body"_"footer"] grid-rows-[minmax(min-content,max-content)_minmax(min-content,auto)_minmax(min-content,max-content)]'>{children} </Layout.Page>
-	)
-}
-
-const Header = ({ children }: { children: ComponentChildren }) => <Layout.Header class='grid [grid-template-areas:_"brand"_"profile"] md:[grid-template-areas:_"brand_profile"] md:items-center md:justify-between gap-4 py-4 px-6'>{children}</Layout.Header>
-
-const Body = ({ children }: { children: ComponentChildren }) => <Layout.Body class='grid gap-6 [grid-template-areas:_"essentials"_"main"_"aside"] md:[grid-template-areas:_"main_essentials"_"main_aside"] md:grid-cols-[3fr_2fr] xl:grid-cols-[5fr_2fr] md:grid-rows-[minmax(min-content,max-content)_1fr] px-6'>{children}</Layout.Body>
 
 const Main = () => {
 	return (
@@ -235,9 +200,7 @@ const SendActions = () => {
 	}
 }
 
-
 const TokenSelectField = () => {
-
 	return <div class='flex flex-col gap-1'>
 		<div class='text-sm text-white/50'>Token</div>
 		<div class='appearance-none relative flex items-center px-3 h-10 bg-white/5 w-full outline-none disabled:bg-white/5 disabled:text-white/30 invalid:text-red-200 border-b border-white/30 focus:border-b-white'>
@@ -245,62 +208,3 @@ const TokenSelectField = () => {
 		</div>
 	</div>
 }
-
-const Footer = () => {
-	return (
-		<Layout.Footer class='h-16 col-span-2 flex items-center justify-center px-8'>
-			<SocialLinks />
-		</Layout.Footer>
-	)
-}
-
-const Branding = () => (
-	<div class='flex flex-col justify-center items-start grow'>
-		<div class='text-3xl font-bold'>Lunaria</div>
-		<div class='text-sm text-white/50'>Manage your digital assets</div>
-	</div>
-)
-
-const SocialLinks = () => (
-	<div class='flex items-center gap-6 text-white/30'>
-		<a class='text-white/30 hover:text-white' href='/'>
-			Github
-		</a>
-		<a class='text-white/30 hover:text-white' href='/'>
-			Twitter
-		</a>
-		<a class='text-white/30 hover:text-white' href='/'>
-			Discord
-		</a>
-	</div>
-)
-
-const Support = () => {
-	return (
-		<div class='bg-white/5 py-3 px-6 hover:bg-white/5 mb-6 text-center md:text-left'>
-			<div class='font-bold text-lg mb-2'>Need support?</div>
-			<div class='text-sm text-white/50 mb-2'>Join our discord channel to get support from our active community members and stay up-to-date with the latest news, events, and announcements.</div>
-		</div>
-	)
-}
-
-const EthBalance = () => (
-	<div class='flex flex-col items-center justify-center md:items-start md:gap-1 mb-2'>
-		<div class='uppercase text-white/50 text-xs md:text-sm'>balance (ETH)</div>
-		<div class='flex items-center gap-2'>
-			<div class='text-lg font-bold capitalize'>100.0159 ETH</div>
-			<button type='button' class='focus:outline-none focus:bg-white/10 focus:ring-1 focus:ring-white rounded' title='Refresh' onClick={() => { }}>
-				<Icon.Refresh />
-			</button>
-		</div>
-	</div>
-)
-
-const ActiveNetwork = () => (
-	<div class='flex flex-col items-center justify-center md:items-start md:gap-1 mb-2'>
-		<div class='uppercase text-white/50 text-xs md:text-sm'>network</div>
-		<div class='text-lg font-bold capitalize' title='0x5'>
-			Goerli
-		</div>
-	</div>
-)

--- a/app/ts/components/SendEthPage.tsx
+++ b/app/ts/components/SendEthPage.tsx
@@ -139,20 +139,19 @@ const TokenSelectField = () => {
 }
 
 const SendForm = ({ children }: { children: ComponentChildren }) => {
+	const transfer = transferStore.value
 	const [_transactionResponse, resolveTransactionResponse] = useTransactionResponse()
-	const handleSubmit = (event: Event) => {
-		event.preventDefault()
-		resolveTransactionResponse()
-	}
 
-	switch (transferStore.value.status) {
+	switch (transfer.status) {
 		case 'new':
-			return <form onSubmit={handleSubmit}>{children}</form>
+			return <form onSubmit={(event: Event) => { event.preventDefault(); resolveTransactionResponse() }}>{children}</form>
+		case 'signed':
+			return <form onSubmit={(event: Event) => { event.preventDefault(); location.href = `#tx/${transfer.transactionResponse.hash}` }}>{children}</form>
 		case 'confirmed':
 		case 'idle':
 		case 'signed':
 			return <>{children}</>
-		default: assertUnreachable(transferStore.value)
+		default: assertUnreachable(transfer)
 	}
 
 }

--- a/app/ts/components/SendEthPage.tsx
+++ b/app/ts/components/SendEthPage.tsx
@@ -1,11 +1,11 @@
+import { ComponentChildren } from 'preact'
 import * as Layout from './Layout.js'
 import { AddressField } from './AddressField.js'
 import { AmountField } from './AmountField.js'
-import { ComponentChildren } from 'preact'
-import { sendTransactionStore, TransactionComposing, TransactionFailed, TransactionStore } from '../store/transaction.js'
 import { accountStore } from '../store/account.js'
-import { useEffect } from 'preact/hooks'
 import { assertUnreachable } from '../library/utilities.js'
+import { transferStore } from '../store/transfer.js'
+import { useAsyncState } from '../library/preact-utilities.js'
 
 export const SendEthPage = () => {
 	return (
@@ -20,183 +20,121 @@ export const SendEthPage = () => {
 }
 
 const Main = () => {
-	return (
-		<SendForm>
-			<div class='grid [grid-template-areas:_"title"_"token"_"amount"_"address"_"tip"_"controls"] grid-rows-[repeat(auto-fit,minmax(min-content,0))] gap-y-4 lg:[grid-template-areas:_"title_title"_"token_amount"_"address_address"_"tip_tip"_"controls_controls"] lg:gap-x-6 xl:[grid-template-areas:_"title_title_title"_"token_amount_tip"_"address_address_tip"_"controls_controls_tip"] lg:grid-cols-2 xl:grid-cols-3'>
-				<div class='[grid-area:title]'>
-					<div class='bg-white/10 text-xl font-bold px-6 py-2 -ml-6'>Send Funds</div>
-				</div>
-				<div class='[grid-area:token]'>
-					<TokenSelectField />
-				</div>
-				<div class='[grid-area:amount]'>
-					<SendAmountField />
-				</div>
-				<div class='[grid-area:address]'>
-					<SendAddressField />
-				</div>
-				<div class='[grid-area:tip] border border-dashed border-white/30'>
-					<SendGuide />
-				</div>
-				<div class='[grid-area:controls]'>
-					<SendActions />
-				</div>
-			</div>
-		</SendForm>
-	)
+	const [transactionResponseAsync, resolveTransactionResponse] = useAsyncState()
+	const transfer = transferStore.value
+
+	switch (transfer.status) {
+		case 'idle':
+			transfer.new()
+			return null
+
+		case 'new':
+			return (
+				<form onSubmit={(event: Event) => { event.preventDefault(); resolveTransactionResponse(transfer.sendTransaction) }}>
+					<MainLayout>
+						<div class='[grid-area:token]'>
+							<TokenSelectField />
+						</div>
+						<div class='[grid-area:amount]'>
+							<AmountField value={transfer.transactionRequest.amount} onChange={(amount) => transferStore.value = { ...transfer, transactionRequest: { ...transfer.transactionRequest, amount } }} label='Amount' name='amount' disabled={transactionResponseAsync.state === 'pending'} />
+						</div>
+						<div class='[grid-area:address]'>
+							<AddressField value={transfer.transactionRequest.to} onChange={(to) => transferStore.value = { ...transfer, transactionRequest: { ...transfer.transactionRequest, to } }
+							} label='Address' name='to' disabled={transactionResponseAsync.state === 'pending'} />
+						</div>
+						<div class='[grid-area:tip] border border-dashed border-white/30'>
+							<SendGuide />
+						</div>
+						<div class='[grid-area:controls]'>
+							<SendActions />
+						</div>
+					</MainLayout>
+				</form>
+			)
+
+		case 'signed':
+		case 'confirmed':
+			return null
+	}
 }
 
-const SendForm = ({ children }: { children: ComponentChildren }) => {
-	const txn = sendTransactionStore
-	const account = accountStore
-
-	function handleSubmit(event: Event) {
-		event.preventDefault()
-		switch (account.value.status) {
-			case 'disconnected':
-				return account.value.connect()
-			case 'connected': {
-				return handleSubmitWhileConnected()
-			}
-			case 'busy':
-			case 'rejected':
-				return
-			default:
-				assertUnreachable(account.value)
-		}
-	}
-
-	function handleSubmitWhileConnected() {
-		switch (txn.value.status) {
-			case 'composing':
-				txn.value.send()
-				break
-			case 'signed':
-				location.href = `#tx/${txn.value.transaction.hash}`
-				break
-			case 'failed':
-				txn.value.reset()
-				break
-			case 'idle':
-				txn.value.status
-				break
-			case 'idle':
-			case 'signing':
-			case 'confirmed':
-			case 'confirming':
-				break
-			default:
-				assertUnreachable(txn.value)
-		}
-	}
-
-	useEffect(() => {
-		txn.value.status === 'idle' && txn.value.compose()
-	}, [])
-
-	return <form onSubmit={handleSubmit}>{children}</form>
-}
-
-const isEditInputAllowed = (store: TransactionStore): store is TransactionComposing | TransactionFailed =>
-	store.status === 'composing' || store.status === 'failed'
-
-const SendAmountField = () => {
-	const txn = sendTransactionStore
-
-	function handleChange(amount: string) {
-		if (!isEditInputAllowed(txn.value)) return
-		txn.value.data = { ...txn.value.data, amount }
-		if (txn.value.status === 'failed') txn.value.reset()
-	}
-
-	const inputValue = txn.value.status === 'idle' ? '' : txn.value.data.amount
-	const disabled = !isEditInputAllowed(txn.value)
-
-	return <AmountField value={inputValue} onChange={handleChange} label='Amount' name='amount' disabled={disabled} />
-}
-
-const SendAddressField = () => {
-	const txn = sendTransactionStore
-
-	function handleChange(to: string) {
-		if (!isEditInputAllowed(txn.value)) return
-		txn.value.data = { ...txn.value.data, to }
-		if (txn.value.status === 'failed') txn.value.reset()
-	}
-
-	const inputValue = txn.value.status === 'idle' ? '' : txn.value.data.to
-	const disabled = !isEditInputAllowed(txn.value)
-
-	return <AddressField value={inputValue} onChange={handleChange} label='Address' name='to' disabled={disabled} />
+const MainLayout = ({ children }: { children: ComponentChildren }) => {
+	return <div class='grid [grid-template-areas:_"title"_"token"_"amount"_"address"_"tip"_"controls"] grid-rows-[repeat(auto-fit,minmax(min-content,0))] gap-y-4 lg:[grid-template-areas:_"title_title"_"token_amount"_"address_address"_"tip_tip"_"controls_controls"] lg:gap-x-6 xl:[grid-template-areas:_"title_title_title"_"token_amount_tip"_"address_address_tip"_"controls_controls_tip"] lg:grid-cols-2 xl:grid-cols-3'>
+		<div class='[grid-area:title]'>
+			<div class='bg-white/10 text-xl font-bold px-6 py-2 -ml-6'>Send Funds</div>
+		</div>
+		{children}
+	</div>
 }
 
 const SendGuide = () => {
-	const txn = sendTransactionStore
-
-	switch (txn.value.status) {
-		case 'composing':
-			return (
-				<div class='p-4 text-center xl:text-left'>
-					<div class='mb-2'>What happens when I click send?</div>
-					<div class='leading-tight text-white/50 text-sm'>This app will forward your request to the wallet you chose to connect with. The connected wallet handles signing and submitting your request to the chain.</div>
-				</div>
-			)
-		case 'signing':
-			return (
-				<div class='p-4 text-center xl:text-left'>
-					<div class='mb-2 font-bold'>Awaiting wallet confirmation...</div>
-					<div class='leading-tight text-white/50 text-sm'>At this point, your connected wallet will need action to proceed with this transaction. Carefully check the information before accepting the wallet confirmation.</div>
-				</div>
-			)
+	const transfer = transferStore.value
+	switch (transfer.status) {
+		// case 'new':
+		// 	return (
+		// 		<div class='p-4 text-center xl:text-left'>
+		// 			<div class='mb-2'>What happens when I click send?</div>
+		// 			<div class='leading-tight text-white/50 text-sm'>This app will forward your request to the wallet you chose to connect with. The connected wallet handles signing and submitting your request to the chain.</div>
+		// 		</div>
+		// 	)
+		// case 'signed':
+		// 	return (
+		// 		<div class='p-4 text-center xl:text-left'>
+		// 			<div class='mb-2 font-bold'>Awaiting wallet confirmation...</div>
+		// 			<div class='leading-tight text-white/50 text-sm'>At this point, your connected wallet will need action to proceed with this transaction. Carefully check the information before accepting the wallet confirmation.</div>
+		// 		</div>
+		// 	)
+		// case 'signed':
+		// 	return (
+		// 		<div class='p-4 text-center xl:text-left'>
+		// 			<div class='mb-2 font-bold'>Request Successfully Sent!</div>
+		// 			<div class='leading-tight text-white/50 text-sm'>Your transaction is awaiting confirmation from the chain. You may click on the View Transaction button to check it's status.</div>
+		// 		</div>
+		// 	)
+		// case 'confirmed':
+		// 	return (
+		// 		<div class='p-4 text-center xl:text-left'>
+		// 			<div class='mb-2 font-bold'>Wallet returned an error!</div>
+		// 			<div class='leading-tight xl:border-l-4 xl:border-l-white/30 px-3 py-1 flex items-center justify-center xl:justify-start text-white/50 text-sm'>{txn.value.error.message}</div>
+		// 			<div class='text-sm mt-2'>Check that your inputs are correct and click Send again.</div>
+		// 		</div>
+		// 	)
 		case 'signed':
-			return (
-				<div class='p-4 text-center xl:text-left'>
-					<div class='mb-2 font-bold'>Request Successfully Sent!</div>
-					<div class='leading-tight text-white/50 text-sm'>Your transaction is awaiting confirmation from the chain. You may click on the View Transaction button to check it's status.</div>
-				</div>
-			)
-		case 'failed':
-			return (
-				<div class='p-4 text-center xl:text-left'>
-					<div class='mb-2 font-bold'>Wallet returned an error!</div>
-					<div class='leading-tight xl:border-l-4 xl:border-l-white/30 px-3 py-1 flex items-center justify-center xl:justify-start text-white/50 text-sm'>{txn.value.error.message}</div>
-					<div class='text-sm mt-2'>Check that your inputs are correct and click Send again.</div>
-				</div>
-			)
 		case 'confirmed':
-		case 'confirming':
+		case 'new':
 		case 'idle':
 			// handle confirmation views on transaction page
 			return null
-		default: assertUnreachable(txn.value)
+		default: assertUnreachable(transfer)
 	}
 }
 
 const SendActions = () => {
 	const account = accountStore
-	const txn = sendTransactionStore
 
 	switch (account.value.status) {
 		case 'busy':
 			return <div class='px-4 py-2 hover:bg-white/10 border w-full'>Connecting...</div>
 		case 'connected':
-			switch (txn.value.status) {
-				case 'composing':
-					return <button type='submit' class='px-4 py-2 hover:bg-white/10 border w-full'>Send</button>
-				case 'signed':
-					return <button type='submit' class='px-4 py-2 hover:bg-white/10 border w-full'>View Transaction</button>
-				case 'confirmed':
-				case 'confirming':
-				case 'idle':
-				case 'signing':
-				case 'failed':
-					return <button type='submit' class='px-4 py-2 bg-white/10 text-white/20 w-full' disabled>Send</button>
-				default: assertUnreachable(txn.value)
-			}
+			return <ActionsConnected />
 		case 'disconnected':
 			return <button type='submit' class='px-4 py-2 hover:bg-white/10 border w-full'>Connect Wallet</button>
 		case 'rejected':
 			return <div class='px-4 py-2 bg-red-400/10 border border-red-400/50 text-white/50 text-center cursor-not-allowed'>Unable to connect to wallet!</div>
+	}
+}
+
+const ActionsConnected = () => {
+	const transfer = transferStore.value
+	switch (transfer.status) {
+		case 'new':
+			return <button type='submit' class='px-4 py-2 hover:bg-white/10 border w-full'>Send</button>
+		case 'signed':
+			return <button type='submit' class='px-4 py-2 hover:bg-white/10 border w-full'>View Transaction</button>
+		case 'confirmed':
+		case 'idle':
+			return <button type='submit' class='px-4 py-2 bg-white/10 text-white/20 w-full' disabled>Loading...</button>
+		default: assertUnreachable(transfer)
 	}
 }
 

--- a/app/ts/components/SendEthPage.tsx
+++ b/app/ts/components/SendEthPage.tsx
@@ -44,7 +44,7 @@ const Main = () => {
 					<div class='[grid-area:address]'>
 						<SendToField />
 					</div>
-					<div class='[grid-area:tip] border border-dashed border-white/30'>
+					<div class='[grid-area:tip] overflow-auto border border-dashed border-white/30'>
 						<SendGuide />
 					</div>
 					<div class='[grid-area:controls]'>
@@ -63,35 +63,32 @@ const SendGuide = () => {
 	switch (transactionResponse.state) {
 		case 'inactive':
 			return (
-				<div class='p-4 text-center xl:text-left'>
-					<div class='mb-2'>What happens when I click send?</div>
-					<div class='leading-tight text-white/50 text-sm'>This app will forward your request to the wallet you chose to connect with. The connected wallet handles signing and submitting your request to the chain.</div>
-				</div>
+				<Guide title='What happens when I click send?' content='This app will forward your request to the wallet you chose to connect with. The connected wallet handles signing and submitting your request to the chain.' />
 			)
 		case 'pending':
 			return (
-				<div class='p-4 text-center xl:text-left'>
-					<div class='mb-2 font-bold'>Awaiting wallet confirmation...</div>
-					<div class='leading-tight text-white/50 text-sm'>At this point, your connected wallet will need action to proceed with this transaction. Carefully check the information before accepting the wallet confirmation.</div>
-				</div>
+				<Guide title='Awaiting wallet confirmation...' content='At this point, your connected wallet will need action to proceed with this transaction. Carefully check the information before accepting the wallet confirmation.' />
 			)
 		case 'resolved':
 			return (
-				<div class='p-4 text-center xl:text-left'>
-					<div class='mb-2 font-bold'>Request Successfully Sent!</div>
-					<div class='leading-tight text-white/50 text-sm'>Your transaction is awaiting confirmation from the chain. You may click on the View Transaction button to check it's status.</div>
-				</div>
+				<Guide title='Request Successfully Sent!' content='Your transaction is awaiting confirmation from the chain. You may click on the View Transaction button to check it&apos;s status.' />
 			)
 		case 'rejected':
 			return (
-				<div class='p-4 text-center xl:text-left'>
-					<div class='mb-2 font-bold'>Wallet returned an error!</div>
-					<div class='leading-tight xl:border-l-4 xl:border-l-white/30 px-3 py-1 flex items-center justify-center xl:justify-start text-white/50 text-sm'>{transactionResponse.error.message}</div>
-					<div class='text-sm mt-2'>Check that your inputs are correct and click Send again.</div>
-				</div>
+				<Guide title='Wallet returned an error!' content='Check that your inputs are correct and click Send again.' quote={transactionResponse.error.message} />
 			)
 		default: assertUnreachable(transactionResponse)
 	}
+}
+
+const Guide = ({ title, quote, content }: { title: string; quote?: string, content: string }) => {
+	return (
+		<div class='p-4 text-center xl:text-left'>
+			<div class='mb-3 font-bold'>{title}</div>
+			{quote && <div class='leading-tight xl:border-l-4 xl:border-l-white/30 px-3 text-white/50 text-sm my-3'>{quote}</div>}
+			<div class='leading-tight text-sm mt-3'>{content}</div>
+		</div>
+	)
 }
 
 const SendActions = () => {
@@ -124,12 +121,14 @@ const ActionsConnected = () => {
 }
 
 const TokenSelectField = () => {
-	return <div class='flex flex-col gap-1'>
-		<div class='text-sm text-white/50'>Token</div>
-		<div class='appearance-none relative flex items-center px-3 h-10 bg-white/5 w-full outline-none disabled:bg-white/5 disabled:text-white/30 invalid:text-red-200 border-b border-white/30 focus:border-b-white'>
-			<div class='cursor-pointer'>ETH</div>
+	return (
+		<div class='flex flex-col gap-1'>
+			<div class='text-sm text-white/50'>Token</div>
+			<div class='appearance-none relative flex items-center px-3 h-10 bg-white/5 w-full outline-none disabled:bg-white/5 disabled:text-white/30 invalid:text-red-200 border-b border-white/30 focus:border-b-white'>
+				<div class='cursor-pointer'>ETH</div>
+			</div>
 		</div>
-	</div>
+	)
 }
 
 const SendForm = ({ children }: { children: ComponentChildren }) => {
@@ -161,7 +160,7 @@ const SendAmountField = () => {
 
 	switch (transfer.status) {
 		case 'new':
-			return <AmountField value={transfer.transactionRequest.amount} onChange={handleChange} label='Amount' name='amount' disabled={transactionResponse.state === 'pending'} />
+			return <AmountField value={transfer.transactionRequest.amount} onChange={handleChange} label='Amount' name='amount' disabled={transactionResponse.state === 'pending'} required />
 		case 'signed':
 			return <AmountField value={ethers.utils.formatEther(transfer.transactionResponse.value!)} onChange={handleChange} label='Amount' name='amount' disabled />
 		case 'idle':
@@ -182,7 +181,7 @@ const SendToField = () => {
 
 	switch (transfer.status) {
 		case 'new':
-			return <AddressField value={transfer.transactionRequest.to} onChange={handleChange} label='To' name='to' disabled={transactionResponse.state === 'pending'} />
+			return <AddressField value={transfer.transactionRequest.to} onChange={handleChange} label='To' name='to' disabled={transactionResponse.state === 'pending'} required />
 		case 'signed':
 			return <AddressField value={transfer.transactionResponse.to!} onChange={handleChange} label='To' name='to' disabled />
 		case 'idle':
@@ -192,11 +191,20 @@ const SendToField = () => {
 	}
 }
 
-const FormLayout = ({ children }: { children: ComponentChildren }) => {
-	return <div class='grid [grid-template-areas:_"title"_"token"_"amount"_"address"_"tip"_"controls"] grid-rows-[repeat(auto-fit,minmax(min-content,0))] gap-y-4 lg:[grid-template-areas:_"title_title"_"token_amount"_"address_address"_"tip_tip"_"controls_controls"] lg:gap-x-6 xl:[grid-template-areas:_"title_title_title"_"token_amount_tip"_"address_address_tip"_"controls_controls_tip"] lg:grid-cols-2 xl:grid-cols-3'>
+const PageTitle = () => {
+	return (
 		<div class='[grid-area:title]'>
 			<div class='bg-white/10 text-xl font-bold px-6 py-2 -ml-6'>Send Funds</div>
 		</div>
-		{children}
-	</div>
+	)
+}
+
+
+const FormLayout = ({ children }: { children: ComponentChildren }) => {
+	return (
+		<div class='grid [grid-template-areas:_"title"_"token"_"amount"_"address"_"tip"_"controls"] grid-rows-[repeat(auto-fit,minmax(min-content,0))] gap-y-4 lg:[grid-template-areas:_"title_title"_"token_amount"_"address_address"_"tip_tip"_"controls_controls"] lg:gap-x-6 xl:[grid-template-areas:_"title_title_title"_"token_amount_tip"_"address_address_tip"_"controls_controls_tip"] lg:grid-cols-2 xl:grid-cols-3'>
+			<PageTitle />
+			{children}
+		</div>
+	)
 }

--- a/app/ts/components/SendEthPage.tsx
+++ b/app/ts/components/SendEthPage.tsx
@@ -54,6 +54,7 @@ const Main = () => {
 
 		case 'signed':
 		case 'confirmed':
+			window.location.href = `#tx/${transfer.transactionResponse.hash}`
 			return null
 	}
 }

--- a/app/ts/components/TransactionDetailsPage.tsx
+++ b/app/ts/components/TransactionDetailsPage.tsx
@@ -5,7 +5,7 @@ import { useParams } from './HashRouter.js'
 import { assertUnreachable, calculateGasFee, isTransactionHash } from '../library/utilities.js'
 import { assertTransferStatus, transferStore } from '../store/transfer.js'
 import { useAsyncState } from '../library/preact-utilities.js'
-import * as Icon from "./Icon/index.js"
+import * as Icon from './Icon/index.js'
 
 export const TransactionDetailsPage = () => {
 	return (
@@ -24,7 +24,7 @@ const Main = () => {
 	const transfer = transferStore
 	const hash = extractTransactionHashFromParams()
 
-	if (!hash) return <TransactionDetailsInvalid />
+	if (hash === null) return <TransactionDetailsInvalid />
 
 	switch (transfer.value.status) {
 		case 'idle':
@@ -35,7 +35,8 @@ const Main = () => {
 			return <TransactionDetailsConfirmed />
 		case 'new':
 			return null // render should be handled in send page
-		default: assertUnreachable(transfer.value)
+		default:
+			assertUnreachable(transfer.value)
 	}
 }
 
@@ -48,7 +49,7 @@ const TransactionDetailsIdle = () => {
 
 	const fetchTransactionResponse = () => {
 		resolveTransactionResponse(async () => {
-			if (!hash || transferStore.value.status !== 'idle') return
+			if (hash === null || transferStore.value.status !== 'idle') return
 			await transferStore.value.fetchTransactionByHash(hash)
 		})
 	}
@@ -81,7 +82,6 @@ const TransactionDetailsIdle = () => {
 						<div class='w-64 h-4 my-1 bg-white/30 animate-pulse rounded' />
 					</InfoLabel>
 				</div>
-
 			)
 		case 'rejected':
 			return (
@@ -93,7 +93,7 @@ const TransactionDetailsIdle = () => {
 							<Icon.Refresh />
 							<span>Retry</span>
 						</button>
-						<button class='hover:underline underline-offset-4 flex items-center gap-1' onClick={() => { }}>
+						<button class='hover:underline underline-offset-4 flex items-center gap-1' onClick={() => {}}>
 							<Icon.Copy />
 							<span>Copy Transaction Hash</span>
 						</button>
@@ -102,7 +102,8 @@ const TransactionDetailsIdle = () => {
 			)
 		case 'resolved':
 			return null
-		default: assertUnreachable(transactionResponse)
+		default:
+			assertUnreachable(transactionResponse)
 	}
 }
 
@@ -159,7 +160,7 @@ const TransactionDetailsSigned = () => {
 							<Icon.Refresh />
 							<span>Retry</span>
 						</button>
-						<button class='hover:underline underline-offset-4 flex items-center gap-1' onClick={() => { }}>
+						<button class='hover:underline underline-offset-4 flex items-center gap-1'>
 							<Icon.Copy />
 							<span>Copy Transaction Hash</span>
 						</button>
@@ -168,7 +169,8 @@ const TransactionDetailsSigned = () => {
 			)
 		case 'resolved':
 			return null
-		default: assertUnreachable(transactionReceipt)
+		default:
+			assertUnreachable(transactionReceipt)
 	}
 }
 

--- a/app/ts/components/TransactionDetailsPage.tsx
+++ b/app/ts/components/TransactionDetailsPage.tsx
@@ -1,0 +1,218 @@
+import { ComponentChildren } from 'preact'
+import { ethers } from 'ethers'
+import * as Layout from './Layout.js'
+import { useParams } from './HashRouter.js'
+import { assertUnreachable, calculateGasFee, isTransactionHash } from '../library/utilities.js'
+import { transferStore } from '../store/transfer.js'
+import { useAsyncState } from '../library/preact-utilities.js'
+import * as Icon from "./Icon/index.js"
+
+export const TransactionDetailsPage = () => {
+	return (
+		<Layout.Page>
+			<Layout.Header />
+			<Layout.Body>
+				<PageTitle />
+				<Main />
+			</Layout.Body>
+			<Layout.Footer />
+		</Layout.Page>
+	)
+}
+
+const Main = () => {
+	const transfer = transferStore
+	const hash = extractTransactionHashFromParams()
+
+	if (!hash) return <TransactionDetailsInvalid />
+
+	switch (transfer.value.status) {
+		case 'idle':
+			return <TransactionDetailsIdle />
+		case 'signed':
+			return <TransactionDetailsSigned />
+		case 'confirmed':
+			return <TransactionDetailsConfirmed />
+		default:
+			return null
+	}
+}
+
+const TransactionDetailsIdle = () => {
+	const transfer = transferStore.value
+	const hash = extractTransactionHashFromParams()
+	const [transactionResponse, resolveTransactionResponse, resetTransactionResponse] = useAsyncState()
+
+	const fetchTransactionResponse = () => {
+		resolveTransactionResponse(async () => {
+			if (!hash || transfer.status !== 'idle') return
+			await transfer.fetchTransactionByHash(hash)
+		})
+	}
+
+	switch (transactionResponse.state) {
+		case 'inactive':
+			fetchTransactionResponse()
+			return null
+		case 'pending':
+			return (
+				<div class='grid grid-cols-1 xl:grid-cols-[repeat(2,_minmax(min-content,_1fr))] gap-x-6'>
+					<div class='border-b border-dashed border-white/10 py-2 xl:col-span-full'>
+						<div class='text-white/50 text-sm'>Transaction Hash:</div>
+						<div class='w-full max-w-[40rem] h-4 my-1 bg-white/30 animate-pulse rounded' />
+					</div>
+					<InfoLabel>
+						<div class='text-white/50 text-sm'>From:</div>
+						<div class='w-96 h-4 my-1 bg-white/30 animate-pulse rounded' />
+					</InfoLabel>
+					<InfoLabel>
+						<div class='text-white/50 text-sm'>To:</div>
+						<div class='w-96 h-4 my-1 bg-white/30 animate-pulse rounded' />
+					</InfoLabel>
+					<InfoLabel>
+						<div class='text-white/30 text-sm'>Amount:</div>
+						<div class='w-64 h-4 my-1 bg-white/30 animate-pulse rounded' />
+					</InfoLabel>
+					<InfoLabel>
+						<div class='text-white/50 text-sm'>Transacton Fee:</div>
+						<div class='w-64 h-4 my-1 bg-white/30 animate-pulse rounded' />
+					</InfoLabel>
+				</div>
+
+			)
+		case 'rejected':
+			return (
+				<div class='border border-dashed border-red-400/30 bg-red-400/5 p-4 text-center'>
+					<div>An issue was encounterd while obtaining transaction details.</div>
+					<div class='px-2 py-1 text-sm text-white/50 my-2'>{transactionResponse.error.message}</div>
+					<div class='flex flex-wrap justify-center gap-y-1 gap-x-6'>
+						<button class='hover:underline underline-offset-4 flex items-center gap-1' onClick={() => resetTransactionResponse()}>
+							<Icon.Refresh />
+							<span>Retry</span>
+						</button>
+						<button class='hover:underline underline-offset-4 flex items-center gap-1' onClick={() => { }}>
+							<Icon.Copy />
+							<span>Copy Transaction Hash</span>
+						</button>
+					</div>
+				</div>
+			)
+		case 'resolved':
+			return null
+		default: assertUnreachable(transactionResponse)
+	}
+}
+
+const TransactionDetailsSigned = () => {
+	const transfer = transferStore.value
+	const [transactionReceipt, resolveTransactionReceipt, resetTransactionReceipt] = useAsyncState()
+
+	const fetchTransactionReceipt = () => {
+		resetTransactionReceipt()
+		resolveTransactionReceipt(async () => {
+			if (transfer.status !== 'signed') return
+			await transfer.fetchTransactionReceipt()
+		})
+	}
+
+	if (transfer.status !== 'signed') return null
+
+	switch (transactionReceipt.state) {
+		case 'inactive':
+			fetchTransactionReceipt()
+			return null
+		case 'pending':
+			return (
+				<div class='grid grid-cols-1 xl:grid-cols-[repeat(2,_minmax(min-content,_1fr))] gap-x-6'>
+					<div class='border-b border-dashed border-white/10 py-2 xl:col-span-full'>
+						<div class='text-white/50 text-sm'>Transaction Hash:</div>
+						<div class='overflow-scroll no-scrollbar'>{transfer.transactionResponse.hash}</div>
+					</div>
+					<InfoLabel>
+						<div class='text-white/50 text-sm'>From:</div>
+						<div>{transfer.transactionResponse.from}</div>
+					</InfoLabel>
+					<InfoLabel>
+						<div class='text-white/50 text-sm'>To:</div>
+						<div>{transfer.transactionResponse.to}</div>
+					</InfoLabel>
+					<InfoLabel>
+						<div class='text-white/50 text-sm'>Amount:</div>
+						<div>{ethers.utils.formatEther(transfer.transactionResponse.value)} Ether</div>
+					</InfoLabel>
+					<InfoLabel>
+						<div class='text-white/50 text-sm'>Transacton Fee:</div>
+						<div class='w-64 h-4 my-1 bg-white/30 animate-pulse rounded' />
+					</InfoLabel>
+				</div>
+			)
+		case 'rejected':
+			return (
+				<div class='border border-dashed border-red-400/30 bg-red-400/5 p-4 text-center'>
+					<div>An issue was encounterd while obtaining transaction details.</div>
+					<div class='px-2 py-1 text-sm text-white/50 my-2'>{transactionReceipt.error.message}</div>
+					<div class='flex flex-wrap justify-center gap-y-1 gap-x-6'>
+						<button class='hover:underline underline-offset-4 flex items-center gap-1' onClick={() => resetTransactionReceipt()}>
+							<Icon.Refresh />
+							<span>Retry</span>
+						</button>
+						<button class='hover:underline underline-offset-4 flex items-center gap-1' onClick={() => { }}>
+							<Icon.Copy />
+							<span>Copy Transaction Hash</span>
+						</button>
+					</div>
+				</div>
+			)
+		case 'resolved':
+			return null
+		default: assertUnreachable(transactionReceipt)
+	}
+}
+
+const TransactionDetailsConfirmed = () => {
+	const transfer = transferStore.value
+
+	if (transfer.status !== 'confirmed') return null
+
+	const transactionFee = calculateGasFee(transfer.transactionReceipt.effectiveGasPrice, transfer.transactionReceipt.gasUsed)
+
+	return (
+		<div class='grid grid-cols-1 xl:grid-cols-[repeat(2,_minmax(min-content,_1fr))] gap-x-6'>
+			<div class='border-b border-dashed border-white/10 py-2 xl:col-span-full'>
+				<div class='text-white/50 text-sm'>Transaction Hash:</div>
+				<div class='overflow-scroll no-scrollbar'>{transfer.transactionResponse.hash}</div>
+			</div>
+			<InfoLabel>
+				<div class='text-white/50 text-sm'>From:</div>
+				<div>{transfer.transactionResponse.from}</div>
+			</InfoLabel>
+			<InfoLabel>
+				<div class='text-white/50 text-sm'>To:</div>
+				<div>{transfer.transactionResponse.to}</div>
+			</InfoLabel>
+			<InfoLabel>
+				<div class='text-white/50 text-sm'>Amount:</div>
+				<div>{ethers.utils.formatEther(transfer.transactionResponse.value)} Ether</div>
+			</InfoLabel>
+			<InfoLabel>
+				<div class='text-white/50 text-sm'>Transacton Fee:</div>
+				<div>{transactionFee} Ether</div>
+			</InfoLabel>
+		</div>
+	)
+}
+
+const TransactionDetailsInvalid = () => {
+	return <div class='p-2 border border-dashed border-white/30 my-4'>Invalid transaction hash</div>
+}
+
+const PageTitle = () => {
+	return <div class='bg-white/10 text-xl font-bold px-6 py-2 -ml-6 mb-4'>Transaction Details</div>
+}
+
+const InfoLabel = ({ children }: { children: ComponentChildren }) => <div class='border-b border-dashed border-white/10 py-2'>{children}</div>
+
+function extractTransactionHashFromParams() {
+	const params = useParams()
+	return params && 'transaction_hash' in params && isTransactionHash(params.transaction_hash) ? params.transaction_hash : null
+}

--- a/app/ts/components/TransactionPage.tsx
+++ b/app/ts/components/TransactionPage.tsx
@@ -17,12 +17,12 @@ export const TransactionPage = () => {
 }
 
 const Main = () => {
-	const hash = useSignal('')
+	const hashFieldInput = useSignal<string>('')
 
 	const handleSubmit = (event: JSX.TargetedEvent<HTMLFormElement>) => {
 		event.preventDefault()
 		transferStore.value = transferStoreDefaults
-		window.location.href = `#tx/${hash.value}`
+		window.location.href = `#tx/${hashFieldInput.value}`
 	}
 
 	return (
@@ -31,8 +31,10 @@ const Main = () => {
 				<div class='text-2xl md:text-3xl font-bold'>Inspect Transaction</div>
 				<div class='text-white/50 text-sm mb-8'>View details of a submitted transaction, inspect fees, or event track progress status of your transfers.</div>
 				<form onSubmit={handleSubmit}>
-					<TransactionHashField onInput={(value) => hash.value = value} />
-					<button class='px-6 py-2 border mt-4 hover:bg-white/10' type='submit'>Inspect</button>
+					<TransactionHashField onInput={value => (hashFieldInput.value = value)} />
+					<button class='px-6 py-2 border mt-4 hover:bg-white/10' type='submit'>
+						Inspect
+					</button>
 				</form>
 			</div>
 		</div>
@@ -40,7 +42,6 @@ const Main = () => {
 }
 
 export const TransactionHashField = ({ onInput }: { onInput: (value: string) => void }) => {
-
 	function handleInput(e: JSX.TargetedEvent<HTMLInputElement>) {
 		const field = e.currentTarget
 		const validity = ethers.utils.hexDataLength(field.value) === 32 ? '' : 'Please enter a valid transaction hash'

--- a/app/ts/components/TransactionPage.tsx
+++ b/app/ts/components/TransactionPage.tsx
@@ -1,0 +1,57 @@
+import { useSignal } from '@preact/signals'
+import { ethers } from 'ethers'
+import { JSX } from 'preact/jsx-runtime'
+import { transferStore } from '../store/transfer.js'
+import * as Layout from './Layout.js'
+
+export const TransactionPage = () => {
+	return (
+		<Layout.Page>
+			<Layout.Header />
+			<Layout.Body>
+				<Main />
+			</Layout.Body>
+			<Layout.Footer />
+		</Layout.Page>
+	)
+}
+
+const Main = () => {
+	const hash = useSignal('')
+
+	const handleSubmit = (event: JSX.TargetedEvent<HTMLFormElement>) => {
+		event.preventDefault()
+		transferStore.value.status !== 'idle' && transferStore.value.reset()
+		window.location.href = `#tx/${hash.value}`
+	}
+
+	return (
+		<div class='flex justify-center h-full w-full py-[10%] text-center'>
+			<div class='w-full max-w-lg'>
+				<div class='text-2xl md:text-3xl font-bold'>Inspect Transaction</div>
+				<div class='text-white/50 text-sm mb-8'>View details of a submitted transaction, inspect fees, or event track progress status of your transfers.</div>
+				<form onSubmit={handleSubmit}>
+					<TransactionHashField onInput={(value) => hash.value = value} />
+					<button class='px-6 py-2 border mt-4 hover:bg-white/10' type='submit'>Inspect</button>
+				</form>
+			</div>
+		</div>
+	)
+}
+
+export const TransactionHashField = ({ onInput }: { onInput: (value: string) => void }) => {
+
+	function handleInput(e: JSX.TargetedEvent<HTMLInputElement>) {
+		const field = e.currentTarget
+		const validity = ethers.utils.hexDataLength(field.value) === 32 ? '' : 'Please enter a valid transaction hash'
+		field.setCustomValidity(validity)
+		field.reportValidity()
+		onInput(field.value)
+	}
+
+	return (
+		<div class='flex flex-col gap-1'>
+			<input name='transaction_hash' autoComplete='off' type='text' onInput={handleInput} class='appearance-none relative flex px-3 h-10 bg-white/5 w-full outline-none disabled:bg-white/5 invalid:text-red-200 border-b border-white/30 focus:border-b-white text-center placeholder:text-white/30' placeholder='Enter transaction hash' required />
+		</div>
+	)
+}

--- a/app/ts/components/TransactionPage.tsx
+++ b/app/ts/components/TransactionPage.tsx
@@ -1,7 +1,7 @@
 import { useSignal } from '@preact/signals'
 import { ethers } from 'ethers'
 import { JSX } from 'preact/jsx-runtime'
-import { transferStore } from '../store/transfer.js'
+import { transferStore, transferStoreDefaults } from '../store/transfer.js'
 import * as Layout from './Layout.js'
 
 export const TransactionPage = () => {
@@ -21,7 +21,7 @@ const Main = () => {
 
 	const handleSubmit = (event: JSX.TargetedEvent<HTMLFormElement>) => {
 		event.preventDefault()
-		transferStore.value.status !== 'idle' && transferStore.value.reset()
+		transferStore.value = transferStoreDefaults
 		window.location.href = `#tx/${hash.value}`
 	}
 

--- a/app/ts/components/TransferContext.tsx
+++ b/app/ts/components/TransferContext.tsx
@@ -1,0 +1,35 @@
+import { ComponentChildren, createContext } from "preact"
+import { useContext } from "preact/hooks"
+import { AsyncProperty, useAsyncState } from "../library/preact-utilities.js"
+import { assertTransferStatus, transferStore, TransferTransaction } from "../store/transfer.js"
+
+export type TransferContext = {
+	asyncResponse: readonly [AsyncProperty<unknown>, () => void, () => void]
+	store: TransferTransaction
+}
+
+const TransferContext = createContext<TransferContext | undefined>(undefined)
+
+export const TransferProvider = ({ children }: { children: ComponentChildren }) => {
+	const [response, resolve, reset] = useAsyncState()
+
+	const send = () => {
+		assertTransferStatus(transferStore.value.status, 'new')
+		resolve(transferStore.value.sendTransaction)
+	}
+
+	const contextValues = {
+		asyncResponse: [response, send, reset] as const,
+		store: transferStore.value
+	}
+
+	return (
+		<TransferContext.Provider value={contextValues}>{children}</TransferContext.Provider>
+	)
+}
+
+export function useTransfer(): TransferContext {
+	const transferContext = useContext(TransferContext)
+	if (!transferContext) throw new Error('useTransfer must be a child of TransferProvider')
+	return transferContext
+}

--- a/app/ts/library/utilities.ts
+++ b/app/ts/library/utilities.ts
@@ -42,3 +42,17 @@ export function isEthereumObservable(ethereum: unknown): ethereum is EthereumWit
 export function assertUnreachable(value: never): never {
 	throw new Error(`Never gonna give you up (${value})`)
 }
+
+export function isTransactionHash(hash: string): hash is `0x${string}` {
+	return ethers.utils.hexDataLength(hash) === 32
+}
+
+export function assertsTransactionHash(hash: string): asserts hash is `0x${string}` {
+	if (!isTransactionHash(hash)) throw new Error('Invalid transaction hash')
+}
+
+export const calculateGasFee = (effectiveGasPrice: ethers.BigNumber, gasUsed: ethers.BigNumber) => {
+	const gasFeeBigNum = effectiveGasPrice.mul(gasUsed)
+	const gasFee = ethers.utils.formatEther(gasFeeBigNum)
+	return gasFee
+}

--- a/app/ts/store/transfer.ts
+++ b/app/ts/store/transfer.ts
@@ -66,5 +66,5 @@ function createNewTransfer() {
 }
 
 export function assertTransferStatus<T extends TransferTransaction['status']>(status: string, requiredStatus: T): asserts status is T {
-	if (status !== requiredStatus) throw new Error(`Transfer status "${status}" should match ${requiredStatus}`)
+	if (status !== requiredStatus) throw new Error(`Transfer status "${status}" did not match required "${requiredStatus}"`)
 }

--- a/app/ts/store/transfer.ts
+++ b/app/ts/store/transfer.ts
@@ -1,0 +1,52 @@
+import { signal } from '@preact/signals'
+import { ethers } from 'ethers'
+import { assertsExternalProvider, assertsTransactionHash } from '../library/utilities.js'
+import { TransactionReceipt, TransactionResponse } from '../types.js'
+
+type TransactionRequest = {
+	to: `0x${string}`
+	amount: string
+	type: 'ETH' | 'LINK'
+}
+
+export type TransferTransaction =
+	| {
+			status: 'unsigned'
+			request: TransactionRequest
+			send: () => Promise<void>
+	  }
+	| {
+			status: 'signed'
+			request: Readonly<TransactionRequest>
+			transactionResponse: TransactionResponse
+			fetch: (hash: string) => Promise<void>
+	  }
+	| {
+			status: 'confirmed'
+			request: Readonly<TransactionRequest>
+			transactionResponse: TransactionResponse
+			transactionReceipt: TransactionReceipt
+	  }
+
+const storeDefaults = { status: 'unsigned', request: { to: '0x', amount: '', type: 'ETH' }, send: initiateTransfer } as const
+export const transferStore = signal<TransferTransaction>(storeDefaults)
+
+async function initiateTransfer() {
+	assertsExternalProvider(window.ethereum)
+	const provider = new ethers.providers.Web3Provider(window.ethereum)
+	const signer = provider.getSigner()
+	const value = ethers.utils.parseEther(transferStore.value.request.amount)
+	const to = ethers.utils.getAddress(transferStore.value.request.to)
+	const transactionResponse = await signer.sendTransaction({ to, value })
+	transferStore.value = { ...transferStore.value, status: 'signed', fetch: (hash: string) => fetchTransactionByHash(hash), transactionResponse }
+}
+
+async function fetchTransactionByHash(hash: TransactionResponse['hash']) {
+	if (transferStore.value.status !== 'signed') return
+	assertsTransactionHash(hash)
+	assertsExternalProvider(window.ethereum)
+	const provider = new ethers.providers.Web3Provider(window.ethereum)
+	const transaction = await provider.getTransaction(hash)
+	const transactionReceipt = await transaction.wait()
+	transferStore.value = { ...transferStore.value, status: 'confirmed', transactionReceipt }
+}

--- a/app/ts/store/transfer.ts
+++ b/app/ts/store/transfer.ts
@@ -12,7 +12,7 @@ export type TransferTransaction =
 	| {
 			status: 'idle'
 			fetchTransactionByHash: (hash: string) => Promise<void>
-			new: () => void
+			createNewTransfer: () => void
 	  }
 	| {
 			status: 'new'
@@ -30,7 +30,7 @@ export type TransferTransaction =
 			transactionReceipt: TransactionReceipt
 	  }
 
-export const transferStoreDefaults = { status: 'idle', fetchTransactionByHash, new: createNewTransfer } as const
+export const transferStoreDefaults = { status: 'idle', fetchTransactionByHash, createNewTransfer } as const
 export const transferStore = signal<TransferTransaction>(transferStoreDefaults)
 
 async function sendTransaction() {

--- a/twcss/tailwind.globals.css
+++ b/twcss/tailwind.globals.css
@@ -377,6 +377,15 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
 		display: table;
 	}
 
+	.no-scrollbar::-webkit-scrollbar {
+		display: none; /* Chrome, Safari and Opera */
+	}
+
+	.no-scrollbar {
+		-ms-overflow-style: none; /* IE and Edge */
+		scrollbar-width: none; /* Firefox */
+	}
+
 	.bg-polka {
 		background-image: radial-gradient(rgba(255, 255, 255, 0.15) 0.5px, transparent 0.5px);
 		background-size: 20px 20px;


### PR DESCRIPTION
WIP for Transaction details page

- [x] View details of a transaction
- [x] Automatically wait for confirmation to calculate transaction fee
- [x] Added a manual transaction search page
<img width="642" alt="Screenshot 2023-01-26 at 10 53 06 AM" src="https://user-images.githubusercontent.com/1169838/214748039-b95cce2c-63cf-4236-ad6e-84200a1ed555.png">

- [x] switch send eth page to new hook to utilize useAsyncState
- [x] handle UI for presenting errors to user